### PR TITLE
Fix footer displacement

### DIFF
--- a/src/components/Footer/__snapshots__/test.tsx.snap
+++ b/src/components/Footer/__snapshots__/test.tsx.snap
@@ -33,7 +33,7 @@ exports[`<Footer /> should render 4 column topics 1`] = `
 
 .c2 {
   display: grid;
-  grid-template-columns: repeat(2,1fr);
+  grid-template-columns: minmax(auto,50%) 1fr;
   gap: 3.2rem;
   margin-top: 3.2rem;
 }
@@ -46,6 +46,11 @@ exports[`<Footer /> should render 4 column topics 1`] = `
   text-decoration: none;
   margin-bottom: 0.8rem;
   font-size: 1.4rem;
+}
+
+.c3 a {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .c3 a:hover {

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -12,7 +12,7 @@ export const Wrapper = styled.footer`
 export const Content = styled.div`
   ${({ theme }) => css`
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: minmax(auto, 50%) 1fr;
     gap: ${theme.grid.gutter};
     margin-top: ${theme.spacings.medium};
 
@@ -31,6 +31,10 @@ export const Column = styled.div`
       text-decoration: none;
       margin-bottom: ${theme.spacings.xxsmall};
       font-size: ${theme.font.sizes.small};
+    }
+    a {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
     a:hover {
       text-decoration: underline;


### PR DESCRIPTION
### Description

Fixes the Footer component, in mobile version, in order to allow larger emails (in contact block) 
preserving the style of the second column.

### Screenshots

|Before                    |After
| ---------------------------------- | ---------------------------------- |
| ![grid-columns](https://user-images.githubusercontent.com/50624358/94928905-b995a980-049a-11eb-8382-3fb056cc4299.png) | ![grid-columns-2](https://user-images.githubusercontent.com/50624358/94928931-c4e8d500-049a-11eb-8c7f-07e093dba4e4.png) |