### PR TITLE
Add validation support to TextField component

### DIFF
--- a/src/components/Form/test.tsx
+++ b/src/components/Form/test.tsx
@@ -13,11 +13,11 @@ describe('<Form />', () => {
     )
 
     expect(container.parentElement).toMatchInlineSnapshot(`
-      .c0 .sc-jSFkmK {
+      .c0 .sc-gKAblj {
         margin: 0.8rem 0;
       }
 
-      .c0 .sc-gKAblj {
+      .c0 .sc-iCoHVE {
         margin: 3.2rem auto 1.6rem;
       }
 

--- a/src/components/TextField/__snapshots__/test.tsx.snap
+++ b/src/components/TextField/__snapshots__/test.tsx.snap
@@ -110,10 +110,10 @@ exports[`<TextField /> Renders with error 1`] = `
       value=""
     />
   </div>
-  <p
+  <span
     class="c9"
   >
     Error message
-  </p>
+  </span>
 </div>
 `

--- a/src/components/TextField/index.tsx
+++ b/src/components/TextField/index.tsx
@@ -11,6 +11,7 @@ export type TextFieldProps = {
   iconPosition?: 'left' | 'right'
   disabled?: boolean
   error?: string
+  loading?: string
 } & InputHTMLAttributes<HTMLInputElement>
 
 const TextField = ({
@@ -20,6 +21,7 @@ const TextField = ({
   labelFor = '',
   initialValue = '',
   error,
+  loading,
   disabled = false,
   onInput,
   ...props
@@ -34,7 +36,7 @@ const TextField = ({
   }
 
   return (
-    <S.Wrapper disabled={disabled} error={!!error}>
+    <S.Wrapper disabled={disabled} error={!!error} isLoading={!!loading}>
       {!!label && <S.Label htmlFor={labelFor}>{label}</S.Label>}
       <S.InputWrapper>
         {!!icon && <S.Icon iconPosition={iconPosition}>{icon}</S.Icon>}
@@ -48,6 +50,7 @@ const TextField = ({
         />
       </S.InputWrapper>
       {!!error && <S.Error>{error}</S.Error>}
+      {loading && <S.Loading>{loading}</S.Loading>}
     </S.Wrapper>
   )
 }

--- a/src/components/TextField/stories.tsx
+++ b/src/components/TextField/stories.tsx
@@ -36,3 +36,13 @@ export const withError: Story<TextFieldProps> = (args) => (
 withError.args = {
   error: 'Ops...something is wrong'
 }
+
+export const withLoading: Story<TextFieldProps> = (args) => (
+  <div style={{ maxWidth: 300, padding: 15 }}>
+    <TextField {...args} />
+  </div>
+)
+
+withLoading.args = {
+  loading: 'Validating...'
+}

--- a/src/components/TextField/styles.ts
+++ b/src/components/TextField/styles.ts
@@ -4,7 +4,9 @@ import { TextFieldProps } from '.'
 
 type IconPositionProps = Pick<TextFieldProps, 'iconPosition'>
 
-type WrapperProps = Pick<TextFieldProps, 'disabled'> & { error?: boolean }
+type WrapperProps = Pick<TextFieldProps, 'disabled'> & { error?: boolean } & {
+  isLoading?: boolean
+}
 
 export const InputWrapper = styled.div`
   ${({ theme }) => css`
@@ -56,10 +58,37 @@ export const Icon = styled.div<IconPositionProps>`
   `}
 `
 
-export const Error = styled.p`
+export const Error = styled.span`
   ${({ theme }) => css`
     color: ${theme.colors.red};
     font-size: ${theme.font.sizes.xsmall};
+  `}
+`
+
+export const Loading = styled.span`
+  ${({ theme }) => css`
+    position: relative;
+    padding-left: 2rem;
+    color: ${theme.colors.primary};
+    font-size: ${theme.font.sizes.xsmall};
+
+    &::before {
+      content: '';
+      top: 0;
+      left: 0;
+      position: absolute;
+      border: 0.2rem solid ${theme.colors.lightGray};
+      border-left-color: ${theme.colors.primary};
+      border-radius: 50%;
+      width: ${theme.font.sizes.small};
+      height: ${theme.font.sizes.small};
+      animation: spin 1s linear infinite;
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    }
   `}
 `
 
@@ -72,6 +101,11 @@ const wrapperModifiers = {
     ${Icon},
     ${Label} {
       color: ${theme.colors.red};
+    }
+  `,
+  loading: (theme: DefaultTheme) => css`
+    ${InputWrapper} {
+      border-color: ${theme.colors.primary};
     }
   `,
   disabled: (theme: DefaultTheme) => css`
@@ -89,8 +123,9 @@ const wrapperModifiers = {
 }
 
 export const Wrapper = styled.div<WrapperProps>`
-  ${({ theme, error, disabled }) => css`
+  ${({ theme, error, isLoading, disabled }) => css`
     ${error && wrapperModifiers.error(theme)}
+    ${isLoading && wrapperModifiers.loading(theme)}
     ${disabled && wrapperModifiers.disabled(theme)}
   `}
 `

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -85,6 +85,20 @@ describe('<TextField />', () => {
     expect(onInput).not.toHaveBeenCalled()
   })
 
+  it('should render with loading', () => {
+    renderWithTheme(
+      <TextField
+        icon={<Email data-testid="icon" />}
+        id="TextField"
+        label="TextField"
+        labelFor="TextField"
+        loading="Validating..."
+      />
+    )
+
+    expect(screen.getByText('Validating...')).toBeInTheDocument()
+  })
+
   it('Renders with error', () => {
     const { container } = renderWithTheme(
       <TextField


### PR DESCRIPTION
### Description
It adds support for a loading state at `TextField` component

|Result|
| ---------------------------------- | 
| ![TextFieldLoading](https://user-images.githubusercontent.com/50624358/98312736-1bbd5f00-1fb1-11eb-900f-5e556c3e38bb.gif) | 

Obs: I have also changed Error element to be a `span` in order to share same spacing with input

![error](https://user-images.githubusercontent.com/50624358/98312926-7656bb00-1fb1-11eb-9a2a-d46ef74c31d2.png)
