### PR TITLE
Ignore stories.tsx when jest is in watch mode

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,8 @@ module.exports = {
   moduleNameMapper: {
     '^styled-components':
       '<rootDir>/node_modules/styled-components/dist/styled-components.browser.cjs.js'
-  }
+  },
+  watchPathIgnorePatterns: [
+    'stories.tsx'
+  ]
 }


### PR DESCRIPTION
In development, is it necessary to run the tests every time the stories are modified?