### PR TITLE
Fix GameItem Heading height

### DIFF
--- a/src/components/GameItem/styles.ts
+++ b/src/components/GameItem/styles.ts
@@ -73,6 +73,13 @@ export const DownloadLink = styled.a`
   ${({ theme }) => css`
     color: ${theme.colors.primary};
     margin-left: ${theme.spacings.xxsmall};
+    position: relative;
+
+    & > svg {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+    }
   `}
 `
 


### PR DESCRIPTION
### Description
At **GameItem** component, the **download link icon** changes the heading height (affecting other elements position) . It is more evident at smaller screens, when doing **default/withPayment** stories comparison.
In this PR the icon SVG is changed to be `position:absolute` in order to not affect heading height.

### Screenshots

|Before                    |After
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/100943391-ea667f00-34db-11eb-89ab-96f8be0d4f23.png) | ![after](https://user-images.githubusercontent.com/50624358/100943408-f18d8d00-34db-11eb-8dcb-cdb6c960be1a.png) |


