### PR TITLE
Fix icon height at TextField component in Safari

### DIFF
--- a/src/components/FormSignIn/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignIn/__snapshots__/test.tsx.snap
@@ -52,6 +52,7 @@ exports[`<FormSignIn /> should render the form 1`] = `
 
 .c3 > svg {
   width: 2.2rem;
+  height: 100%;
 }
 
 .c8 {
@@ -238,4 +239,4 @@ exports[`<FormSignIn /> should render the form 1`] = `
     </div>
   </div>
 </body>
-`
+`;

--- a/src/components/FormSignUp/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignUp/__snapshots__/test.tsx.snap
@@ -52,6 +52,7 @@ exports[`<FormSignUp /> should render the form 1`] = `
 
 .c3 > svg {
   width: 2.2rem;
+  height: 100%;
 }
 
 .c7 {
@@ -292,4 +293,4 @@ exports[`<FormSignUp /> should render the form 1`] = `
     </div>
   </form>
 </div>
-`
+`;

--- a/src/components/TextField/__snapshots__/test.tsx.snap
+++ b/src/components/TextField/__snapshots__/test.tsx.snap
@@ -58,6 +58,7 @@ exports[`<TextField /> Renders with error 1`] = `
 
 .c6 > svg {
   width: 2.2rem;
+  height: 100%;
 }
 
 .c9 {

--- a/src/components/TextField/styles.ts
+++ b/src/components/TextField/styles.ts
@@ -52,6 +52,7 @@ export const Icon = styled.div<IconPositionProps>`
 
     & > svg {
       width: 2.2rem;
+      height: 100%;
     }
   `}
 `

--- a/src/templates/Home/styles.ts
+++ b/src/templates/Home/styles.ts
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components'
 import media from 'styled-media-query'
 
 import * as HeadingStyles from 'components/Heading/styles'
-import * as HighlightStyles from 'components/Highlight/styles'
 
 export const SectionBanner = styled.section`
   ${({ theme }) => css`

--- a/src/templates/Home/test.tsx
+++ b/src/templates/Home/test.tsx
@@ -10,11 +10,15 @@ import Home from '.'
 
 const props = {
   banners: bannerMock,
+  newGamesTitle: 'News',
   newGames: gamesMock,
+  mostPopularGamesTitle: 'Most Popular',
   mostPopularHighlight: highlightMock,
   mostPopularGames: gamesMock,
+  upcomingGamesTitle: 'Upcoming',
   upcomingGames: gamesMock,
   upcomingHighlight: highlightMock,
+  freeGamesTitle: 'Free Games',
   freeGames: gamesMock,
   freeHighlight: highlightMock
 }


### PR DESCRIPTION
### Description
When opening **TextField** component in Safari, the icon takes **150px** of height (is this caused by the default 300x150 svg size?),  as only **width** is set, modifying the input height. 

The suggestion in this PR is to set `height: 100%` for the SVG. Would be `max-height: 100%` a better idea?

|Screenshot                    | 
| ---------------------------------- | 
|  <img width="386" alt="textfield-1" src="https://user-images.githubusercontent.com/50624358/106372474-c940d400-634e-11eb-8119-74ca24a1269b.png">|
