### PR TITLE
fix: Heading color to SectionNews in mobile version

### DIFF
--- a/src/templates/Home/styles.ts
+++ b/src/templates/Home/styles.ts
@@ -1,7 +1,6 @@
+import * as HeadingStyles from 'components/Heading/styles'
 import styled, { css } from 'styled-components'
 import media from 'styled-media-query'
-
-import * as HeadingStyles from 'components/Heading/styles'
 
 export const SectionBanner = styled.section`
   ${({ theme }) => css`
@@ -18,6 +17,10 @@ export const SectionBanner = styled.section`
 export const SectionNews = styled.div`
   ${({ theme }) => css`
     margin-bottom: calc(${theme.spacings.xxlarge} * 2);
+
+    ${HeadingStyles.Wrapper} {
+      color: ${theme.colors.white};
+    }
 
     ${media.greaterThan('large')`
       margin-top: -13rem;


### PR DESCRIPTION
Description:
Change heading color to SectionNews when in mobile/tablets versions.

Before:

![image](https://user-images.githubusercontent.com/43195123/107299184-87521500-6a55-11eb-82a6-af5eeec64869.png)

After:
![image](https://user-images.githubusercontent.com/43195123/107299219-9cc73f00-6a55-11eb-9cbb-147b84253be4.png)
