### PR TITLE
Fix storybook controls

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,5 +4,15 @@ module.exports = {
   webpackFinal: (config) => {
     config.resolve.modules.push(`${process.cwd()}/src`)
     return config
+  },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      shouldExtractLiteralValuesFromEnum: true,
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@styled-icons/remix-fill": "^10.18.0",
     "@types/lodash.xor": "^4.5.6",
     "graphql": "^15.4.0",
+    "joi": "^17.4.0",
     "lodash.xor": "^4.5.0",
     "next": "10.0.7",
     "next-auth": "^3.11.2",

--- a/src/components/GameInfo/index.tsx
+++ b/src/components/GameInfo/index.tsx
@@ -1,7 +1,4 @@
-import {
-  AddShoppingCart,
-  FavoriteBorder
-} from '@styled-icons/material-outlined'
+import { FavoriteBorder } from '@styled-icons/material-outlined'
 
 import Button from 'components/Button'
 import CartButton from 'components/CartButton'

--- a/src/components/OrdersList/mock.ts
+++ b/src/components/OrdersList/mock.ts
@@ -1,5 +1,6 @@
 export default [
   {
+    id: '1',
     img: 'https://source.unsplash.com/user/willianjusten/151x70',
     title: 'Red Dead Redemption 2',
     price: 'R$ 215,00',
@@ -12,6 +13,7 @@ export default [
     }
   },
   {
+    id: '2',
     img: 'https://source.unsplash.com/user/willianjusten/151x70',
     title: 'Red Dead Redemption 2',
     price: 'R$ 215,00',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,6 +2176,11 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
   integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
 
+"@hapi/hoek@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
+  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+
 "@hapi/joi@^15.1.0":
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
@@ -2192,6 +2197,13 @@
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@icons/material@^0.2.4":
   version "0.2.4"
@@ -2770,6 +2782,23 @@
   integrity sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
   dependencies:
     any-observable "^0.3.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.1.tgz#9e321e74310963fdf8eebfbee09c7bd69972de4d"
+  integrity sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
@@ -10724,6 +10753,17 @@ jest@^26.6.3:
     "@jest/core" "^26.6.3"
     import-local "^3.0.2"
     jest-cli "^26.6.3"
+
+joi@^17.4.0:
+  version "17.4.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.4.0.tgz#b5c2277c8519e016316e49ababd41a1908d9ef20"
+  integrity sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 jose@^1.27.2, jose@^1.28.0:
   version "1.28.0"


### PR DESCRIPTION
Nas versões anteriores do storybook, alguns args são exibidos no storybook control como um select. Por exemplo, a prop `lineColor` do componente `Heading`:

<img width="907" alt="Screen Shot 2021-03-24 at 11 03 58" src="https://user-images.githubusercontent.com/12154623/112323541-a537aa00-8c90-11eb-9b34-3d35f8af15d6.png">

**(o exemplo acima é exatamente do repositório do client da won games)**

Porém, com a mesma config e mesmo código, na versão 6.1.21 do storybook (**não sei a partir de qual versão ficou assim**), essa opção não é inferida e a é exibida como um texto ao invés de um select:
<img width="907" alt="Screen Shot 2021-03-24 at 11 05 24" src="https://user-images.githubusercontent.com/12154623/112323759-d87a3900-8c90-11eb-8041-ac3637438216.png">

Há uma [discussão no slack a respeito](https://willianjusten-cursos.slack.com/archives/C016MQE9CAD/p1616452778100200). O Giovanny percebeu que usando os valores diretamente ao invés de criar um tipo resolve o problema. Ex.:
**antes:**
```
export type LineColors = 'primary' | 'secondary'

export type HeadingProps = {
  //outros valores
  lineColor?: LineColors
}
```

**depois:**
```
export type LineColors = 'primary' | 'secondary'

export type HeadingProps = {
  //outros valores
  lineColor?: 'primary' | 'secondary'
}
```

Porém, com isso, teríamos de ficar repetindo o código sempre, como ele explicou.

Pesquisando um pouco mais, cheguei até uma [parte da documentação que mostra como sobscrever a configuração para inferir props adicionais](https://storybook.js.org/docs/react/configure/typescript#overriding-the-configuration-to-infer-additional-props). Nesse caso, cheguei a uma configuração que poderíamos usar e que **aparentemente (preciso que outras pessoas também testes e tentem perceber algum problema)** resolve o problema. Nesse caso, continuaria aparecendo um select nas versões anteriores do storybook e um checkbox nas opções mais recentes. A config:
```
typescript: {
    reactDocgen: 'react-docgen-typescript',
    reactDocgenTypescriptOptions: {
      shouldExtractLiteralValuesFromEnum: true,
      compilerOptions: {
        allowSyntheticDefaultImports: false,
        esModuleInterop: false
      }
    }
 }
```

A versão anterior continua da mesma maneira. Na versão mais recente do storybook fica assim após a config (as outras opções permanecem como antes, mas agora o lineColor é inferido como um checkBox também).

<img width="907" alt="Screen Shot 2021-03-24 at 11 16 00" src="https://user-images.githubusercontent.com/12154623/112325307-52f78880-8c92-11eb-8786-497834d79ea5.png">

**Outros links que li enquanto tentava entender o problema:**
- https://github.com/storybookjs/storybook/issues/11019
- https://github.com/storybookjs/storybook/pull/11423
- https://github.com/storybookjs/storybook/pull/11423