### PR TITLE
Fix wishlist button disabled state

### DIFF
--- a/src/components/GameCard/__snapshots__/test.tsx.snap
+++ b/src/components/GameCard/__snapshots__/test.tsx.snap
@@ -244,6 +244,7 @@ exports[`<GameCard /> should render correctly 1`] = `
     >
       <button
         class="c7"
+        style="filter: none;"
       >
         <svg
           aria-hidden="true"
@@ -296,4 +297,4 @@ exports[`<GameCard /> should render correctly 1`] = `
     </div>
   </div>
 </article>
-`;
+`

--- a/src/components/GameInfo/__snapshots__/test.tsx.snap
+++ b/src/components/GameInfo/__snapshots__/test.tsx.snap
@@ -282,6 +282,7 @@ exports[`<GameInfo /> should render game informations 1`] = `
     </button>
     <button
       class="c8"
+      style="filter: none;"
     >
       <svg
         aria-hidden="true"
@@ -306,4 +307,4 @@ exports[`<GameInfo /> should render game informations 1`] = `
     </button>
   </div>
 </div>
-`;
+`

--- a/src/components/WishlistButton/index.tsx
+++ b/src/components/WishlistButton/index.tsx
@@ -17,7 +17,12 @@ const WishlistButton = ({
 }: WishlistButtonProps) => {
   const [session] = useSession()
   const [loading, setLoading] = useState(false)
-  const { isInWishlist, addToWishlist, removeFromWishlist } = useWishlist()
+  const {
+    isInWishlist,
+    addToWishlist,
+    removeFromWishlist,
+    loading: loadingApollo
+  } = useWishlist()
 
   const handleClick = async () => {
     setLoading(true)
@@ -45,6 +50,8 @@ const WishlistButton = ({
       onClick={handleClick}
       minimal
       size={size}
+      disabled={loadingApollo}
+      style={{ filter: 'none' }}
     >
       {hasText && ButtonText}
     </Button>


### PR DESCRIPTION
### Description

While playing with the **WishlistButton** component I realized that if a user has a slow connection and clicks the wishlist button and clicks again quickly on another one (before response arrives) it may occur an unexpected behaviour (request and response not matching).

So I thought maybe this fix coud work: disabling the buttons while the response has not arrive. In order to maintain the appearence (color), I have reset the filter (by default the disabled state has a 30% saturation).

Another option would be to apply different styles on the button for this specific case, `disabled` and `minimal`, (maybe a `cursor: progress`?). The option you think makes more sense. Hope it helps :)

### Screenshots

|Before                    |
| ---------------------------------- | 
| ![mutation](https://user-images.githubusercontent.com/50624358/115940503-35c3fe80-a478-11eb-8b8d-5bdbc8a06806.gif) |

|After|
| ---------------------------------- | 
| ![after-mutation](https://user-images.githubusercontent.com/50624358/115940531-4b392880-a478-11eb-9120-7c3e9986b91c.gif)