### PR TITLE
Fix key of GameItem on OrdersList

### DIFF
--- a/src/components/OrdersList/index.tsx
+++ b/src/components/OrdersList/index.tsx
@@ -22,7 +22,7 @@ const OrdersList = ({ items = [] }: OrdersListProps) => (
     {items.length ? (
       items.map((order) => {
         return order.games.map((game) => (
-          <GameItem key={order.id} {...game} paymentInfo={order.paymentInfo} />
+          <GameItem key={`${order.id}_${game.id}`} {...game} paymentInfo={order.paymentInfo} />
         ))
       })
     ) : (


### PR DESCRIPTION
A key precisando ser única, não poderia ser nem da Order e nem do Game já que ambos tem a probabilidade de ser repetir.
Sendo assim, a alternativa proposta é juntar ambas, já que um Game só existirá uma vez em uma determinada Order.