### PR TITLE
Add Optimistic UI to WishlistButton

### DIFF
--- a/src/components/WishlistButton/index.tsx
+++ b/src/components/WishlistButton/index.tsx
@@ -1,9 +1,9 @@
-import { Favorite, FavoriteBorder } from '@styled-icons/material-outlined'
-import Button, { ButtonProps } from 'components/Button'
-import Spinner from 'components/Spinner'
 import { useWishlist } from 'hooks/use-wishlist'
 import { useSession } from 'next-auth/client'
-import { useState } from 'react'
+
+import Button, { ButtonProps } from 'components/Button'
+
+import { Favorite, FavoriteBorder } from '@styled-icons/material-outlined'
 
 type WishlistButtonProps = {
   id: string
@@ -16,7 +16,7 @@ const WishlistButton = ({
   size = 'small'
 }: WishlistButtonProps) => {
   const [session] = useSession()
-  const [loading, setLoading] = useState(false)
+
   const {
     isInWishlist,
     addToWishlist,
@@ -24,10 +24,8 @@ const WishlistButton = ({
     loading: loadingApollo
   } = useWishlist()
 
-  const handleClick = async () => {
-    setLoading(true)
-    isInWishlist(id) ? await removeFromWishlist(id) : await addToWishlist(id)
-    setLoading(false)
+  const handleClick = () => {
+    return isInWishlist(id) ? removeFromWishlist(id) : addToWishlist(id)
   }
 
   const ButtonText = isInWishlist(id)
@@ -39,9 +37,7 @@ const WishlistButton = ({
   return (
     <Button
       icon={
-        loading ? (
-          <Spinner />
-        ) : isInWishlist(id) ? (
+        isInWishlist(id) ? (
           <Favorite aria-label={ButtonText} />
         ) : (
           <FavoriteBorder aria-label={ButtonText} />


### PR DESCRIPTION
### Description
It adds [Optimistic UI](https://www.apollographql.com/docs/react/v2/performance/optimistic-ui/) pattern for Apollo mutations at **WishlistButton** component.

### Considerations
In order to create an [optimistic response](https://www.apollographql.com/docs/react/v2/performance/optimistic-ui/#basic-optimistic-ui), in the case of **adding to wishlist**, we have an additional complexity: the data of the new added game is not available. Only the **id**.  I thought of two possibilities, but both have problems:

- Pass the game info down to wishlist button. **Problem**: Prop drilling, not ideal.
- As we have the **id** available, we could extract the game fragment info from apollo cache. **Problem**: At `index` page, it is defined `fetchPolicy: 'no-cache'` so we don't have that info within the cache.

The alternative solution used is a function, `optimisticGameResponse`, that creates the boilerplate structure for the optimistic response (adding a '-' before the id). The downside I found by doing like this would be that it may appear an empty game at the`wishlist page` while having the optimistic response causing inconsistency or a "flash". But luckily this case is protected by the loader (pacman) corresponding to apollo loading state.

### Solution
The main change comes at `isInWishlist` function, which now returns three possible states:  

- `-1` (optimistic)
- `0` (not in wishlist)
- `1` (in wishlist)

Not sure if this is the best approach or way of handling it (like the "enum" `IsInWishlistResponse`), would like to know your opinion.

### Screenshots
https://user-images.githubusercontent.com/50624358/118416341-8993c300-b685-11eb-8f74-f4ce08300a65.mp4