### PR TITLE
Fix Accessibility on the games page

### DIFF
--- a/src/components/Banner/__snapshots__/test.tsx.snap
+++ b/src/components/Banner/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Banner /> should render correctly 1`] = `
 }
 
 .c5:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c5:hover {
@@ -156,4 +156,4 @@ exports[`<Banner /> should render correctly 1`] = `
     </a>
   </div>
 </main>
-`;
+`

--- a/src/components/Button/__snapshots__/test.tsx.snap
+++ b/src/components/Button/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Button /> should render the medium size by default 1`] = `
 }
 
 .c0:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c0:hover {
@@ -43,4 +43,4 @@ exports[`<Button /> should render the medium size by default 1`] = `
     Buy now
   </span>
 </button>
-`;
+`

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -65,7 +65,7 @@ export const Wrapper = styled.button<WrapperProps>`
     text-decoration: none;
 
     &:focus {
-      outline: 1px dashed;
+      box-shadow: 0 0 0 3px ${theme.colors.secondary};
     }
 
     &:hover {

--- a/src/components/CartIcon/styles.ts
+++ b/src/components/CartIcon/styles.ts
@@ -1,8 +1,11 @@
 import styled, { css } from 'styled-components'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.button`
   ${({ theme }) => css`
     color: ${theme.colors.white};
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
     width: 2.4rem;
     height: 2.4rem;
     position: relative;

--- a/src/components/Empty/__snapshots__/test.tsx.snap
+++ b/src/components/Empty/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Empty /> should render correctly 1`] = `
 }
 
 .c3:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c3:hover {
@@ -99,4 +99,4 @@ exports[`<Empty /> should render correctly 1`] = `
     </div>
   </div>
 </body>
-`;
+`

--- a/src/components/FormSignIn/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignIn/__snapshots__/test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<FormSignIn /> should render the form 1`] = `
 }
 
 .c8:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c8:hover {
@@ -252,4 +252,4 @@ exports[`<FormSignIn /> should render the form 1`] = `
     </div>
   </div>
 </body>
-`;
+`

--- a/src/components/FormSignUp/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignUp/__snapshots__/test.tsx.snap
@@ -90,7 +90,7 @@ exports[`<FormSignUp /> should render the form 1`] = `
 }
 
 .c7:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c7:hover {
@@ -306,4 +306,4 @@ exports[`<FormSignUp /> should render the form 1`] = `
     </div>
   </form>
 </div>
-`;
+`

--- a/src/components/GameCard/__snapshots__/test.tsx.snap
+++ b/src/components/GameCard/__snapshots__/test.tsx.snap
@@ -36,7 +36,7 @@ exports[`<GameCard /> should render correctly 1`] = `
 }
 
 .c7:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c7:hover {
@@ -82,7 +82,7 @@ exports[`<GameCard /> should render correctly 1`] = `
 }
 
 .c11:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c11:hover {
@@ -293,4 +293,4 @@ exports[`<GameCard /> should render correctly 1`] = `
     </div>
   </div>
 </article>
-`;
+`

--- a/src/components/GameInfo/__snapshots__/test.tsx.snap
+++ b/src/components/GameInfo/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`<GameInfo /> should render game informations 1`] = `
 }
 
 .c6:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c6:hover {
@@ -80,7 +80,7 @@ exports[`<GameInfo /> should render game informations 1`] = `
 }
 
 .c8:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c8:hover {
@@ -308,4 +308,4 @@ exports[`<GameInfo /> should render game informations 1`] = `
     </button>
   </div>
 </div>
-`;
+`

--- a/src/components/Highlight/__snapshots__/test.tsx.snap
+++ b/src/components/Highlight/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Highlight /> should render headings and button 1`] = `
 }
 
 .c5:focus {
-  outline: 1px dashed;
+  box-shadow: 0 0 0 3px #3CD3C1;
 }
 
 .c5:hover {
@@ -138,4 +138,4 @@ exports[`<Highlight /> should render headings and button 1`] = `
     </a>
   </div>
 </section>
-`;
+`

--- a/src/templates/Games/index.tsx
+++ b/src/templates/Games/index.tsx
@@ -85,7 +85,7 @@ const GamesTemplate = ({ filterItems }: GamesTemplateProps) => {
                       alt="Loading more games..."
                     />
                   ) : (
-                    <S.ShowMoreButton role="button" onClick={handleShowMore}>
+                    <S.ShowMoreButton onClick={handleShowMore}>
                       <p>Show More</p>
                       <ArrowDown size={35} />
                     </S.ShowMoreButton>

--- a/src/templates/Games/styles.ts
+++ b/src/templates/Games/styles.ts
@@ -19,13 +19,16 @@ export const ShowMore = styled.div`
   height: 10rem;
 `
 
-export const ShowMoreButton = styled.div`
+export const ShowMoreButton = styled.button`
   ${({ theme }) => css`
     text-align: center;
     text-transform: uppercase;
     font-weight: bold;
     cursor: pointer;
     color: ${theme.colors.white};
+    background-color: transparent;
+    border: none;
+    padding: ${theme.spacings.xsmall};
 
     > svg {
       color: ${theme.colors.primary};


### PR DESCRIPTION
# Fix accessibilities on the games page

## 1. Button not accessible on a lighter background

### Before fix

Users cannot see where the focus is when the button is focused on `GameCard`.

- Games Page

https://user-images.githubusercontent.com/54550926/118577524-f203a280-b760-11eb-8776-9e12b8b660b3.mp4

- Storybook

https://user-images.githubusercontent.com/54550926/118577602-15c6e880-b761-11eb-8213-ec42c99e8d55.mp4

### After fix

- Games Page

https://user-images.githubusercontent.com/54550926/118578001-c7661980-b761-11eb-87cc-3edfb0390990.mp4

- Storybook

https://user-images.githubusercontent.com/54550926/118578031-d5b43580-b761-11eb-8f03-b454d84d5821.mp4

##  2. `CartIcon` component is not accessible

### Before fix

Users cannot access it with `tab` or see when `CartIcon` has focus neither click on it with `Enter` or `Space` Key.

- Games Page

https://user-images.githubusercontent.com/54550926/118578398-7c003b00-b762-11eb-8845-cc6e6c14e047.mp4

- Storybook

https://user-images.githubusercontent.com/54550926/118578442-8b7f8400-b762-11eb-84ff-ead692d75098.mp4

### After fix

- Games Page

https://user-images.githubusercontent.com/54550926/118578527-a8b45280-b762-11eb-965e-5e2717f02bbc.mp4

- Storybook

https://user-images.githubusercontent.com/54550926/118578563-b7026e80-b762-11eb-928d-2cc4420a6bcb.mp4

## 3. `ShowMoreButton` not accessible

### Before fix

Users cannot access it with `tab` or see when `ShowMoreButton` has focus neither click on it with `Enter` or `Space` Key.

- Games Page

https://user-images.githubusercontent.com/54550926/118578650-e6b17680-b762-11eb-9999-ce24040d6687.mp4

### After fix

https://user-images.githubusercontent.com/54550926/118578689-fa5cdd00-b762-11eb-8c47-5fd6f55bef79.mp4
