### PR TITLE
Fix wrong key in orders map

### DIFF
--- a/src/components/OrdersList/index.tsx
+++ b/src/components/OrdersList/index.tsx
@@ -22,7 +22,11 @@ const OrdersList = ({ items = [] }: OrdersListProps) => (
     {items.length ? (
       items.map((order) => {
         return order.games.map((game) => (
-          <GameItem key={game.id} {...game} paymentInfo={order.paymentInfo} />
+          <GameItem
+            key={`${order.id}-${game.id}`}
+            {...game}
+            paymentInfo={order.paymentInfo}
+          />
         ))
       })
     ) : (

--- a/src/components/OrdersList/index.tsx
+++ b/src/components/OrdersList/index.tsx
@@ -22,7 +22,7 @@ const OrdersList = ({ items = [] }: OrdersListProps) => (
     {items.length ? (
       items.map((order) => {
         return order.games.map((game) => (
-          <GameItem key={order.id} {...game} paymentInfo={order.paymentInfo} />
+          <GameItem key={game.id} {...game} paymentInfo={order.paymentInfo} />
         ))
       })
     ) : (


### PR DESCRIPTION
Hey, this way you'll have duplicated key in `GameItem` elements because a single order can have many games.

We're rendering multiple game cards and not a list of orders, each one must have a unique id. Otherwise a wrong game item can be rendered