### PR TITLE
Remove unnecessary await before synchronous method

### DIFF
--- a/src/components/FormResetPassword/test.tsx
+++ b/src/components/FormResetPassword/test.tsx
@@ -18,7 +18,7 @@ jest.mock('next-auth/client', () => ({
   signIn: jest.fn()
 }))
 
-describe('<FormResetPassword>', () => {
+describe('<FormResetPassword />', () => {
   it('should render the form', () => {
     render(<FormResetPassword />)
 
@@ -32,8 +32,8 @@ describe('<FormResetPassword>', () => {
   it('should show validation errors', async () => {
     render(<FormResetPassword />)
 
-    await userEvent.type(screen.getByPlaceholderText('Password'), '123')
-    await userEvent.type(screen.getByPlaceholderText(/confirm/i), '321')
+    userEvent.type(screen.getByPlaceholderText('Password'), '123')
+    userEvent.type(screen.getByPlaceholderText(/confirm/i), '321')
 
     userEvent.click(screen.getByRole('button', { name: /reset password/i }))
 
@@ -44,8 +44,8 @@ describe('<FormResetPassword>', () => {
     query = { code: 'wrong_code' }
     render(<FormResetPassword />)
 
-    await userEvent.type(screen.getByPlaceholderText('Password'), '123')
-    await userEvent.type(screen.getByPlaceholderText(/confirm/i), '123')
+    userEvent.type(screen.getByPlaceholderText('Password'), '123')
+    userEvent.type(screen.getByPlaceholderText(/confirm/i), '123')
 
     userEvent.click(screen.getByRole('button', { name: /reset password/i }))
 
@@ -59,8 +59,8 @@ describe('<FormResetPassword>', () => {
 
     render(<FormResetPassword />)
 
-    await userEvent.type(screen.getByPlaceholderText('Password'), '123')
-    await userEvent.type(screen.getByPlaceholderText(/confirm/i), '123')
+    userEvent.type(screen.getByPlaceholderText('Password'), '123')
+    userEvent.type(screen.getByPlaceholderText(/confirm/i), '123')
 
     userEvent.click(screen.getByRole('button', { name: /reset password/i }))
 


### PR DESCRIPTION
According to Testing Library documentation (https://testing-library.com/docs/ecosystem-user-event/):

"Note: All userEvent methods are synchronous with one exception: when delay option used with userEvent.type as described below."

So I removed await before userEvent.type.