### PR TITLE
Add minor enhancement to Textfield on autocomplete

### DIFF
--- a/src/components/FormSignIn/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignIn/__snapshots__/test.tsx.snap
@@ -45,6 +45,11 @@ exports[`<FormSignIn /> should render the form 1`] = `
   filter: none;
 }
 
+.c5:-webkit-autofill::first-line {
+  font-family: Poppins,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;
+  font-size: 1.6rem;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/FormSignUp/__snapshots__/test.tsx.snap
+++ b/src/components/FormSignUp/__snapshots__/test.tsx.snap
@@ -45,6 +45,11 @@ exports[`<FormSignUp /> should render the form 1`] = `
   filter: none;
 }
 
+.c5:-webkit-autofill::first-line {
+  font-family: Poppins,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;
+  font-size: 1.6rem;
+}
+
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/TextField/__snapshots__/test.tsx.snap
+++ b/src/components/TextField/__snapshots__/test.tsx.snap
@@ -45,6 +45,11 @@ exports[`<TextField /> Renders with error 1`] = `
   filter: none;
 }
 
+.c8:-webkit-autofill::first-line {
+  font-family: Poppins,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,Ubuntu,Cantarell,'Open Sans','Helvetica Neue',sans-serif;
+  font-size: 1.6rem;
+}
+
 .c2 {
   font-size: 1.4rem;
   color: #030517;
@@ -125,4 +130,4 @@ exports[`<TextField /> Renders with error 1`] = `
     Error message
   </p>
 </div>
-`;
+`

--- a/src/components/TextField/styles.ts
+++ b/src/components/TextField/styles.ts
@@ -37,7 +37,11 @@ export const Input = styled.input<IconPositionProps>`
     &:-webkit-autofill {
       -webkit-box-shadow: 0 0 0 ${theme.spacings.small}
         ${theme.colors.lightGray} inset;
-      filter: none
+      filter: none;
+      &::first-line {
+        font-family: ${theme.font.family};
+        font-size: ${theme.font.sizes.medium};
+      }
     }
   `}
 `


### PR DESCRIPTION
### Description
Just a minor enhancement to avoid the font styles shift when hovering on webkit browser's autocomplete suggestions. It uses `first-line` selector to set the font styles.

### Screenshots

|Before                    |After
| ---------------------------------- | ---------------------------------- |
| ![before](https://user-images.githubusercontent.com/50624358/119368007-ee07e100-bc88-11eb-93e6-b91c0e00a79a.gif)  | ![after](https://user-images.githubusercontent.com/50624358/119368049-f9f3a300-bc88-11eb-909f-57eeb37bf773.gif)|