### PR TITLE
feat/global providers

### DIFF
--- a/src/hooks/use-cart/index.tsx
+++ b/src/hooks/use-cart/index.tsx
@@ -40,7 +40,7 @@ export const CartContext = createContext<CartContextData>(
 )
 
 export type CartProviderProps = {
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const CartProvider = ({ children }: CartProviderProps) => {

--- a/src/hooks/use-wishlist/index.tsx
+++ b/src/hooks/use-wishlist/index.tsx
@@ -37,7 +37,7 @@ export const WishlistContext = createContext<WishlistContextData>(
 )
 
 export type WishlistProviderProps = {
-  children: React.ReactNode
+  children?: React.ReactNode
 }
 
 const WishlistProvider = ({ children }: WishlistProviderProps) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,17 +5,12 @@ import SEO from '../../next-seo.config'
 
 import { Provider as AuthProvider } from 'next-auth/client'
 import { ApolloProvider } from '@apollo/client'
-import { ThemeProvider } from 'styled-components'
-import { CartProvider } from 'hooks/use-cart'
-
 import { AppProps } from 'next/app'
 import Head from 'next/head'
-
 import GlobalStyles from 'styles/global'
-import theme from 'styles/theme'
 import { useApollo } from 'utils/apollo'
-import { WishlistProvider } from 'hooks/use-wishlist'
 import { StickyNote } from 'components/StickyNote'
+import { AppProvider } from 'providers/app'
 
 function App({ Component, pageProps }: AppProps) {
   const client = useApollo(pageProps.initialApolloState)
@@ -23,38 +18,33 @@ function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider session={pageProps.session}>
       <ApolloProvider client={client}>
-        <ThemeProvider theme={theme}>
-          <CartProvider>
-            <WishlistProvider>
-              <Head>
-                <title>Won Games</title>
-                <link rel="shortcut icon" href="/img/icon-512.png" />
-                <link rel="apple-touch-icon" href="/img/icon-512.png" />
-                <link rel="manifest" href="/manifest.json" />
-                <meta
-                  name="description"
-                  content="The best Game Store in the world!"
-                />
-              </Head>
-              <DefaultSeo {...SEO} />
-              <GlobalStyles />
-              <NextNprogress
-                color="#F231A5"
-                startPosition={0.3}
-                stopDelayMs={200}
-                height={5}
-              />
-              <StickyNote>
-                <p>
-                  Esse é um site de estudos! Quer fazer um site igual? Aprenda
-                  no curso{' '}
-                  <a href="https://reactavancado.com.br">React Avançado</a>
-                </p>
-              </StickyNote>
-              <Component {...pageProps} />
-            </WishlistProvider>
-          </CartProvider>
-        </ThemeProvider>
+        <AppProvider>
+          <Head>
+            <title>Won Games</title>
+            <link rel="shortcut icon" href="/img/icon-512.png" />
+            <link rel="apple-touch-icon" href="/img/icon-512.png" />
+            <link rel="manifest" href="/manifest.json" />
+            <meta
+              name="description"
+              content="The best Game Store in the world!"
+            />
+          </Head>
+          <DefaultSeo {...SEO} />
+          <GlobalStyles />
+          <NextNprogress
+            color="#F231A5"
+            startPosition={0.3}
+            stopDelayMs={200}
+            height={5}
+          />
+          <StickyNote>
+            <p>
+              Esse é um site de estudos! Quer fazer um site igual? Aprenda no
+              curso <a href="https://reactavancado.com.br">React Avançado</a>
+            </p>
+          </StickyNote>
+          <Component {...pageProps} />
+        </AppProvider>
       </ApolloProvider>
     </AuthProvider>
   )

--- a/src/providers/app.tsx
+++ b/src/providers/app.tsx
@@ -1,0 +1,28 @@
+/* eslint-disable react/jsx-key */
+import { CartProvider } from 'hooks/use-cart'
+import { WishlistProvider } from 'hooks/use-wishlist'
+import theme from 'styles/theme'
+
+import React, { cloneElement, ReactNode } from 'react'
+import { ThemeProvider } from 'styled-components'
+
+interface AppProviderProps {
+  children: ReactNode
+}
+
+const contexts = [
+  <ThemeProvider theme={theme} />,
+  <CartProvider />,
+  <WishlistProvider />
+] as JSX.Element[]
+
+export const AppProvider = ({
+  children: app
+}: AppProviderProps): JSX.Element => (
+  <>
+    {contexts.reduce(
+      (children, parent) => cloneElement(parent, { children }),
+      app
+    )}
+  </>
+)


### PR DESCRIPTION
**Motivação**
Com o crescimento do projeto, provavelmente surgirá necessidade de envolver nossa aplicação com mais providers, porém, esse envólucro de providers pode deixar nosso código com a cara de um hadouken.

![image](https://user-images.githubusercontent.com/35538358/128930249-46910fb5-a854-4c3b-a1ba-3f46471c42df.png)



A ideia com esse PR, é trazer uma forma de centralizar todos os nossos providers e disponibilizá-los de uma única vez.

![image](https://user-images.githubusercontent.com/35538358/128931238-f9e743b7-c1d9-4dcc-a3ae-6627aac1ab67.png)


**Com tudo mapeado, envolvemos o _app.tsx com o `AppProvider`**

![image](https://user-images.githubusercontent.com/35538358/128930209-d779eff5-bec6-4c94-80bf-5ca99914926c.png)


**Pontos importantes:**
- Como o provider do Apollo e de Autenticação utilizam da pageProps, resolvi não mexer por hora.
- os children dos providers devem ser opcionais, assinalados com o `?` (ou, pode-se cercar a tipagem com o Partial)