### PR TITLE
Fix MenuFull focusable when is closed

### DIFF
--- a/src/components/Menu/styles.ts
+++ b/src/components/Menu/styles.ts
@@ -104,6 +104,7 @@ export const MenuFull = styled.nav<MenuFullProps>`
     transition: opacity 0.3s ease-in-out;
     opacity: ${isOpen ? 1 : 0};
     pointer-events: ${isOpen ? 'all' : 'none'};
+    visibility: ${isOpen ? 'visible' : 'hidden'};
 
     > svg {
       position: absolute;


### PR DESCRIPTION
I was testing the accessibility of my project and I noticed that the `MenuFull` is focusable even when it is closed. This PR solves this issue.

## Example

https://user-images.githubusercontent.com/54550926/129822763-53721efc-4ef3-42dc-8093-3a39be92167e.mp4