### PR TITLE
Improve BannerSlider UX and accessibility

### DIFF
--- a/src/components/BannerSlider/styles.ts
+++ b/src/components/BannerSlider/styles.ts
@@ -21,9 +21,14 @@ export const Wrapper = styled.section`
         justify-content: center;
         margin: 0 ${theme.spacings.xxsmall};
         cursor: pointer;
+        transition: box-shadow ${theme.transition.default};
 
         &.slick-active {
           background: ${theme.colors.primary};
+        }
+
+        &:focus-within {
+          box-shadow: 0 0 0 0.3rem ${theme.colors.secondary};
         }
       }
 

--- a/src/components/BannerSlider/styles.ts
+++ b/src/components/BannerSlider/styles.ts
@@ -35,6 +35,14 @@ export const Wrapper = styled.section`
       }
     }
 
+    .slick-slide {
+      visibility: hidden;
+
+      &.slick-active.slick-current {
+        visibility: visible;
+      }
+    }
+
     ${media.greaterThan('large')`
       ${BannerStyles.Wrapper} {
         max-width: 104rem;

--- a/src/components/BannerSlider/test.tsx
+++ b/src/components/BannerSlider/test.tsx
@@ -39,8 +39,8 @@ describe('<BannerSlider />', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.getByRole('heading', { name: /defy death 2/i, hidden: true })
-    ).toBeInTheDocument()
+      screen.queryByRole('heading', { name: /defy death 2/i, hidden: true })
+    ).not.toBeInTheDocument()
   })
 
   it('should render with the dots', () => {


### PR DESCRIPTION
## Before fixes/improvements

### 1. Hidden Banner focusable on `BannerSlider`

Users can focus on a hidden Banner in the `BannerSlider` component, which is not that bad, actually. But when a hidden banner is focused, the slider has a weird behavior.

https://user-images.githubusercontent.com/54550926/129824771-ea07f6d1-3dab-4cd7-81f3-e9829288400e.mp4

### 2. `BannerSlider` slick dots has no focus state

https://user-images.githubusercontent.com/54550926/129825084-b84f290f-714c-4fb9-8d1a-8030eb732da5.mp4

## After fixes/improvements

https://user-images.githubusercontent.com/54550926/129825138-e020e3bc-519b-4057-823d-c63c2ee345dc.mp4