### PR TITLE
feat(stories): add props type in Meta

### DIFF
--- a/src/components/Banner/stories.tsx
+++ b/src/components/Banner/stories.tsx
@@ -19,7 +19,7 @@ export default {
   parameters: {
     layout: 'fullscreen'
   }
-} as Meta
+} as Meta<BannerProps>
 
 export const Default: Story<BannerProps> = (args) => (
   <div style={{ maxWidth: '104rem', margin: '0 auto' }}>

--- a/src/components/BannerSlider/stories.tsx
+++ b/src/components/BannerSlider/stories.tsx
@@ -12,7 +12,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<BannerSliderProps>
 
 export const Default: Story<BannerSliderProps> = (args) => (
   <div style={{ maxWidth: '130rem', margin: '0 auto' }}>

--- a/src/components/Button/stories.tsx
+++ b/src/components/Button/stories.tsx
@@ -24,7 +24,7 @@ export default {
       type: ''
     }
   }
-} as Meta
+} as Meta<ButtonProps>
 
 export const Default: Story<ButtonProps> = (args) => <Button {...args} />
 

--- a/src/components/CartList/stories.tsx
+++ b/src/components/CartList/stories.tsx
@@ -19,7 +19,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<CartListProps>
 
 export const Default: Story = (args) => (
   <div style={{ maxWidth: 800 }}>

--- a/src/components/Checkbox/stories.tsx
+++ b/src/components/Checkbox/stories.tsx
@@ -13,7 +13,7 @@ export default {
   argTypes: {
     onCheck: { action: 'checked' }
   }
-} as Meta
+} as Meta<CheckboxProps>
 
 export const Default: Story<CheckboxProps> = (args) => (
   <>

--- a/src/components/Dropdown/stories.tsx
+++ b/src/components/Dropdown/stories.tsx
@@ -9,7 +9,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<DropdownProps>
 
 export const Default: Story<DropdownProps> = (args) => <Dropdown {...args} />
 

--- a/src/components/Empty/stories.tsx
+++ b/src/components/Empty/stories.tsx
@@ -9,7 +9,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<EmptyProps>
 
 export const Default: Story<EmptyProps> = (args) => <Empty {...args} />
 

--- a/src/components/ExploreSidebar/stories.tsx
+++ b/src/components/ExploreSidebar/stories.tsx
@@ -16,7 +16,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<ExploreSidebarProps>
 
 export const Default: Story<ExploreSidebarProps> = (args) => (
   <div style={{ padding: 16, maxWidth: 320 }}>

--- a/src/components/Gallery/stories.tsx
+++ b/src/components/Gallery/stories.tsx
@@ -14,7 +14,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<GalleryProps>
 
 export const Default: Story<GalleryProps> = (args) => (
   <div style={{ maxWidth: '130rem', margin: '0 auto' }}>

--- a/src/components/GameCard/stories.tsx
+++ b/src/components/GameCard/stories.tsx
@@ -23,7 +23,7 @@ export default {
     onFav: { action: 'clicked' },
     ribbon: { type: 'string' }
   }
-} as Meta
+} as Meta<GameCardProps>
 
 export const Default: Story<GameCardProps> = (args) => (
   <div style={{ width: '30rem' }}>

--- a/src/components/GameCardSlider/stories.tsx
+++ b/src/components/GameCardSlider/stories.tsx
@@ -14,7 +14,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<GameCardProps>
 
 export const Default: Story<GameCardProps[]> = (args) => (
   <div style={{ maxWidth: '130rem', margin: '0 auto' }}>

--- a/src/components/GameDetails/stories.tsx
+++ b/src/components/GameDetails/stories.tsx
@@ -28,7 +28,7 @@ export default {
       }
     }
   }
-} as Meta
+} as Meta<GameDetailsProps>
 
 export const Default: Story<GameDetailsProps> = (args) => (
   <div style={{ maxWidth: '130rem', margin: '0 auto' }}>

--- a/src/components/GameInfo/stories.tsx
+++ b/src/components/GameInfo/stories.tsx
@@ -12,7 +12,7 @@ export default {
     }
   },
   args: mockGame
-} as Meta
+} as Meta<GameInfoProps>
 
 export const Default: Story<GameInfoProps> = (args) => (
   <div style={{ maxWidth: '144rem', margin: 'auto', padding: '1.5rem' }}>

--- a/src/components/GameItem/stories.tsx
+++ b/src/components/GameItem/stories.tsx
@@ -9,7 +9,7 @@ export default {
     title: 'Red Dead Redemption 2',
     price: 'R$ 215,00'
   }
-} as Meta
+} as Meta<GameItemProps>
 
 export const Default: Story<GameItemProps> = (args) => <GameItem {...args} />
 

--- a/src/components/Heading/stories.tsx
+++ b/src/components/Heading/stories.tsx
@@ -9,7 +9,7 @@ export default {
       type: 'string'
     }
   }
-} as Meta
+} as Meta<HeadingProps>
 
 export const Default: Story<HeadingProps> = (args) => <Heading {...args} />
 

--- a/src/components/Highlight/stories.tsx
+++ b/src/components/Highlight/stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Highlight',
   component: Highlight,
   args: { ...item }
-} as Meta
+} as Meta<HighlightProps>
 
 export const Default: Story<HighlightProps> = (args) => (
   <div style={{ maxWidth: '104rem' }}>

--- a/src/components/Logo/stories.tsx
+++ b/src/components/Logo/stories.tsx
@@ -9,6 +9,6 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<LogoProps>
 
 export const Default: Story<LogoProps> = (args) => <Logo {...args} />

--- a/src/components/Menu/stories.tsx
+++ b/src/components/Menu/stories.tsx
@@ -10,7 +10,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<MenuProps>
 
 export const Default: Story<MenuProps> = (args) => <Menu {...args} />
 

--- a/src/components/OrdersList/stories.tsx
+++ b/src/components/OrdersList/stories.tsx
@@ -9,7 +9,7 @@ export default {
   args: {
     items: itemsMock
   }
-} as Meta
+} as Meta<OrdersListProps>
 
 export const Default: Story<OrdersListProps> = (args) => (
   <div style={{ maxWidth: 850, margin: 'auto' }}>

--- a/src/components/ProfileMenu/stories.tsx
+++ b/src/components/ProfileMenu/stories.tsx
@@ -9,7 +9,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<ProfileMenuProps>
 
 export const Default: Story<ProfileMenuProps> = (args) => (
   <ProfileMenu {...args} />

--- a/src/components/Radio/stories.tsx
+++ b/src/components/Radio/stories.tsx
@@ -13,7 +13,7 @@ export default {
   argTypes: {
     onCheck: { action: 'checked' }
   }
-} as Meta
+} as Meta<RadioProps>
 
 export const Default: Story<RadioProps> = (args) => (
   <>

--- a/src/components/Ribbon/stories.tsx
+++ b/src/components/Ribbon/stories.tsx
@@ -12,7 +12,7 @@ export default {
       type: 'string'
     }
   }
-} as Meta
+} as Meta<RibbonProps>
 
 export const Default: Story<RibbonProps> = (args) => (
   <div

--- a/src/components/Showcase/stories.tsx
+++ b/src/components/Showcase/stories.tsx
@@ -19,7 +19,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<ShowcaseProps>
 
 export const Default: Story<ShowcaseProps> = (args) => <Showcase {...args} />
 

--- a/src/components/Spinner/stories.tsx
+++ b/src/components/Spinner/stories.tsx
@@ -4,6 +4,6 @@ import Spinner, { SpinnerProps } from '.'
 export default {
   title: 'Spinner',
   component: Spinner
-} as Meta
+} as Meta<SpinnerProps>
 
 export const Default: Story<SpinnerProps> = (args) => <Spinner {...args} />

--- a/src/components/TextContent/stories.tsx
+++ b/src/components/TextContent/stories.tsx
@@ -11,7 +11,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<TextContentProps>
 
 export const Default: Story<TextContentProps> = (args) => (
   <TextContent {...args} />

--- a/src/components/TextField/stories.tsx
+++ b/src/components/TextField/stories.tsx
@@ -18,7 +18,7 @@ export default {
     onInput: { action: 'changed' },
     icon: { type: '' }
   }
-} as Meta
+} as Meta<TextFieldProps>
 
 export const Default: Story<TextFieldProps> = (args) => (
   <div style={{ maxWidth: 300, padding: 15 }}>

--- a/src/components/UserDropdown/stories.tsx
+++ b/src/components/UserDropdown/stories.tsx
@@ -9,7 +9,7 @@ export default {
       default: 'won-dark'
     }
   }
-} as Meta
+} as Meta<UserDropdownProps>
 
 export const Default: Story<UserDropdownProps> = (args) => (
   <div style={{ maxWidth: '98%', display: 'flex', justifyContent: 'flex-end' }}>


### PR DESCRIPTION
Atualmente o editor não consegue inferir os tipos do `args` nos stories
Essa mudança visa melhorar o autocomplete alem de adicionar uma checagem estatica nos argumentos

Antes:
![image](https://user-images.githubusercontent.com/32439070/146418800-0786fe30-359a-404e-866c-022fed1c4ecc.png)

Depois:
![image](https://user-images.githubusercontent.com/32439070/146418835-782ece2f-0915-41a5-bda3-e4cd6fb85a8a.png)